### PR TITLE
Fix the use of strings in match function

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
           ...cssRule,
           test: /\.module\.css$/,
           use: cssRule.use.map(_ => {
-            if (_ && _.loader && _.loader.match('/\css-loader/g')) {
+            if (_ && _.loader && _.loader.match(/\/css-loader/g)) {
               return {
                 ..._,
                 options: {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match

Match attempts to match a string against a regex. This commit updates the argument sent to match function to be a regex not a string.

Fixes: https://github.com/Negan1911/storybook-css-modules-preset/issues/4