### PR TITLE
Fixed css-lodaer regex for Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
           ...cssRule,
           test: /\.module\.css$/,
           use: cssRule.use.map(_ => {
-            if (_ && _.loader && _.loader.match(/\/css-loader/g)) {
+            if (_ && _.loader && _.loader.match(/[\/\\]css-loader/g)) {
               return {
                 ..._,
                 options: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-css-modules-preset",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "main": "index.js",
   "bugs": {
     "url": "https://github.com/negan1911/storybook-css-modules-preset/issues"


### PR DESCRIPTION
The current regular expression used to update css-loader options does not work for Windows due to difference in path separator. This PR fixes the issue so that this addon works for Windows and *nix. 