### PR TITLE
fix Storybook 6.2 issue with empty rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const css_regex = '/\\.css$/'
 
 module.exports = {
   webpackFinal(config = {}, options = {}) {
-  const cssRule = config.module.rules.find(_ => _.test.toString() === css_regex)
+  const cssRule = config.module.rules.find(_ => _ && _.test && _.test.toString() === css_regex)
 
 
   return {
@@ -10,7 +10,7 @@ module.exports = {
     module: {
       ...config.module,
       rules: [
-        ...config.module.rules.filter(_ => _.test.toString() !== css_regex),
+        ...config.module.rules.filter(_ => _ && _.test && _.test.toString() !== css_regex),
         {
           ...cssRule,
           exclude: /\.module\.css$/,


### PR DESCRIPTION
Storybook 6.2 has an empty object in the config module rules array, causing toString() to be called on undefined, causing the preset to crash Storybook. This fixes it.

Fixes: https://github.com/Negan1911/storybook-css-modules-preset/issues/11